### PR TITLE
index: fix default language explosion

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,7 @@ const Reader = styled.textarea`
 `;
 
 class App extends Component {
-  state = { emoji: '', letters: '', lang: 'en' };
+  state = { emoji: '', letters: '', lang: SUPPORTED_LANGS[0].key };
   read$ = new Subject();
 
   componentDidMount() {


### PR DESCRIPTION
this fixes Cannot read property 'x' of undefined
when no language is provided. Since default value
is set to 'en' which is not listed into
SUPPORTED_LANGS array, we pick SUPPORTED_LANGS[0]
to be sure to pick an existing language